### PR TITLE
Use the 'US/Pacific' timezone

### DIFF
--- a/puppet/puppet
+++ b/puppet/puppet
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 unset RUBYOPT BUNDLE_GEMFILE BUNDLE_BIN_PATH GEM_HOME GEM_PATH GEMRC
 
-# this is because of exceccive calls to stat /etc/localtime
-export TZ=PDT
+# setting this variable inhibits calls to stat /etc/localtime
+# which would otherwise be excessive.
+export TZ='US/Pacific'
 
 export RUBY_GC_HEAP_INIT_SLOTS=600000
 export RUBY_GC_HEAP_FREE_SLOTS=300000


### PR DESCRIPTION
The PDT timezone doesn't exist, causing some weird stuff to happen when Puppet logs to syslog.  Use the US/Pacific timezone instead.

It would be nice to progammatically determine the timezone for this, but I know of no way to do this in a cross-platform manner.  Ideas I considered were:
1) read /etc/timezone (doesn't have to match current timezone, isn't used across all Linuxes)
2) somehow reverse-engineer a correct value of TZ from the contents of /etc/localtime.
