### PR TITLE
RFC: Pass the X-Forwarded-For header into the Puppet master process

### DIFF
--- a/puppet/config.ru
+++ b/puppet/config.ru
@@ -21,5 +21,16 @@ ARGV << "--vardir" << "/var/lib/puppetmaster"
 
 require 'puppet/util/command_line'
 
-run Puppet::Util::CommandLine.new.execute
+class EnvironmentMiddleware
+  def initialize(app)
+    @app = app
+  end
 
+  def call(env)
+    ENV['HTTP_X_FORWARDED_FOR'] = env['HTTP_X_FORWARDED_FOR']
+    @app.call(env)
+  end
+end
+
+use EnvironmentMiddleware
+run Puppet::Util::CommandLine.new.execute


### PR DESCRIPTION
This allows executables called by the Puppet master process to access the HTTP
client's IP address.  Since the policy-based autosigning API uses executables
called by the Puppet master process, this environment variable propagates into
one's autosign.conf setting.

As an example, one could use an autosign.conf script like:

    #!/bin/bash
    set -o errexit
    set -o nounset
    set -o pipefail

    certname="$1"
    dns_ip=$(getent hosts "$certname" | awk '{ print $1 }')
    if [[ "$dns_ip" != "$HTTP_X_FORWARDED_FOR" ]]; then
        exit 1
    fi

This would sign certificates iff the certname has an A record matching the
client's IP.  In such a situation, an attacker would have to spoof either their
IP address or DNS responses to the Puppetmaster in order to obtain a
certificate for a CN that doesn't belong to them.