### PR TITLE
Fix lucid build. This installs trusty's openssl and ca-certs for lucid.

### DIFF
--- a/Rockerfile
+++ b/Rockerfile
@@ -69,6 +69,15 @@ run %Q{
   apt-get -qq install #{packages[env_os].sort.join(' ')} --force-yes
 } if %w{xenial trusty precise lucid}.include? env_os
 
+if env_os == 'lucid'
+  run %Q{
+    wget http://security.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates_20160104ubuntu0.14.04.1_all.deb
+    wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.0.1f-1ubuntu2.19_amd64.deb
+    dpkg -i openssl_1.0.1f-1ubuntu2.19_amd64.deb ca-certificates_20160104ubuntu0.14.04.1_all.deb
+    rm openssl_1.0.1f-1ubuntu2.19_amd64.deb ca-certificates_20160104ubuntu0.14.04.1_all.deb
+  }
+end
+
 # user jenkins
 
 run %Q{


### PR DESCRIPTION
Installing and running puppet also works fine on lucid