### PR TITLE
Pull the version of puppet to build from the environment (puppet_version)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Make sure repository has either tag or branch(not both!) named "VERSION.ITERATION"
 PUPPET_GIT   = ENV["upstream_puppet_git"] || "git://github.com/Yelp/puppet.git"
-VERSION      = "4.3.2"
+VERSION      = ENV["puppet_version"] || "4.3.2"
 ITERATION    = "y1"
 
 PACKAGE_NAME = "puppet-omnibus"


### PR DESCRIPTION
Will default to 4.3.2 if puppet_version is not set.
Tested locally