### PR TITLE
Bumped serverspec

### DIFF
--- a/puppet/Gemfile
+++ b/puppet/Gemfile
@@ -23,7 +23,7 @@ gem 'msgpack',                '0.6.2' # Apache v2
 gem 'puppet-syntax',          '2.0.0'
 gem 'sensu-plugin',           '1.2.0'     # This is used for check_aws_events
 gem 'puppet-lint',            '~> 1.1.0'  # MIT
-gem 'serverspec',             '2.24.1'     # MIT
+gem 'serverspec',             '2.36.0'     # MIT
 gem 'r10k',                   '1.4.1'
 
 # AWS section


### PR DESCRIPTION
This is to get https://github.com/mizzy/serverspec/pull/554 as it was breaking due to an API call removed from rspec.